### PR TITLE
feat: enable sphinx-copybutton by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "docutils>=0.21.2",
     "sphinx~=7.0",
+    "sphinx-copybutton>=0.5.2",
 ]
 license = "GPL-3.0"
 

--- a/sphinx_terminal/__init__.py
+++ b/sphinx_terminal/__init__.py
@@ -16,6 +16,8 @@
 
 """Adds the directive to Sphinx."""
 
+import importlib.util
+
 from sphinx.util.typing import ExtensionMetadata
 from sphinx.application import Sphinx
 from .directive import TerminalDirective
@@ -39,7 +41,14 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     returns: ExtensionMetadata
     """
+    try:
+        if importlib.util.find_spec("sphinx_copybutton") is not None:
+            app.setup_extension("sphinx_copybutton")
+    except ModuleNotFoundError:
+        print("Could not find 'sphinx-copybutton'.")
+
     app.add_directive("terminal", TerminalDirective)
+
     common.add_css(app, "terminal.css")
 
     copybutton_classes = "div.terminal.copybutton > div.container > code.command, div:not(.terminal-code, .no-copybutton) > div.highlight > pre"

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -20,6 +20,7 @@
   display: block;
   padding: 0 0.4rem 0 0.875rem;
   line-height: 1;
+  min-height: 1.3em;
 }
 
 .terminal .input .literal {

--- a/uv.lock
+++ b/uv.lock
@@ -875,11 +875,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
 name = "sphinx-terminal"
 source = { editable = "." }
 dependencies = [
     { name = "docutils" },
     { name = "sphinx" },
+    { name = "sphinx-copybutton" },
 ]
 
 [package.dev-dependencies]
@@ -904,6 +917,7 @@ types = [
 requires-dist = [
     { name = "docutils", specifier = ">=0.21.2" },
     { name = "sphinx", specifier = "~=7.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* Enable `sphinx-copybutton` during setup so that users don't have to add it to `conf.py` manually
* Adjust styling so that the copy button is fully visible