### PR TITLE
fix: add copybutton to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ extensions = [
 The copy button functionality depends on
 [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/).
 sphinx-terminal automatically adds this extension to your Sphinx project and configures
-it to ignore the multiline input prompt.
+it to copy terminal input and ignore the multiline prompt.
 
 ```python
+copybutton_selector = "span.copybutton, div:not(.terminal-code) > div.highlight > pre"
 copybutton_prompt_text = "> |"
 copybutton_prompt_is_regexp = True
 ```

--- a/sphinx_terminal/__init__.py
+++ b/sphinx_terminal/__init__.py
@@ -52,7 +52,9 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     common.add_css(app, "terminal.css")
 
-    copybutton_classes = "span.copybutton"
+    copybutton_classes = (
+        "span.copybutton, div:not(.terminal-code) > div.highlight > pre"
+    )
     if "copybutton_selector" not in app.config.values:
         app.add_config_value("copybutton_selector", copybutton_classes, "html")
     if app.config.copybutton_selector == "div.highlight pre":

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -16,7 +16,6 @@ expected output:
 
     output
 
-
 The following documents include more examples for manual review:
 
 .. toctree::

--- a/tests/integration/example/myst-examples.md
+++ b/tests/integration/example/myst-examples.md
@@ -1,4 +1,4 @@
-# Myst examples
+# MyST examples
 
 ## Multi-line input
 
@@ -41,4 +41,10 @@ output line 3
 input line 1
 input line 2
 input line 3
+```
+
+## Code blocks
+
+```{code-block}
+This should remain copyable.
 ```

--- a/tests/integration/example/rst-examples.rst
+++ b/tests/integration/example/rst-examples.rst
@@ -1,4 +1,4 @@
-RST examples
+rST examples
 ============
 
 Multi-line input
@@ -19,6 +19,7 @@ Multi-line input
 
     output line-3
 
+
 No input
 --------
 
@@ -34,6 +35,7 @@ No input
 
     output line 3
 
+
 No output
 ---------
 
@@ -46,3 +48,11 @@ No output
 
     input line 1
     input line 2
+
+
+Code blocks
+-----------
+
+.. code-block::
+
+    This should remain copyable.


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Ensures that sphinx-terminal doesn't compromise the default behavior of the sphinx-copybutton extension.