### PR TITLE
style: change white-space-collapse to preserve-breaks

### DIFF
--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -24,7 +24,7 @@
 }
 
 .terminal .input .literal {
-  white-space-collapse: break-spaces;
+  white-space-collapse: preserve-breaks;
   background: transparent;
 }
 


### PR DESCRIPTION
The white-space-collapse with break-spaces options causes the $ sign to be followed by two whitespaces.  A minor cosmetic thing but unnecessary.
Changing this to preserve-breaks instead which still keeps the intended behaviour for multi-line input.

Current "white-space-collapse: break-spaces" with additional whitespace after the "$" sign:
<img width="539" height="143" alt="image" src="https://github.com/user-attachments/assets/31dd10d8-2134-4034-8123-e59b1cdde387" />

Updated "white-space-collapse: preserve-breaks":
<img width="539" height="143" alt="image" src="https://github.com/user-attachments/assets/4cdb2e63-42be-4464-97f8-fc84b3494531" />


- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
