### PR TITLE
feat: merge consecutive terminals

### DIFF
--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -3,6 +3,18 @@
   color: #ebebeb;
   border: 1px solid #666;
   padding: 0.625rem 0;
+
+  /* Followed by another terminal */
+  &:has(+ &) {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  /* Preceded by another terminal */
+  & + & {
+    border-top: 0;
+    padding-top: 0;
+  }
 }
 
 .terminal .highlight {
@@ -45,7 +57,7 @@
 }
 
 div.terminal-code {
-  margin: 0 0;
+  margin: 0;
 }
 
 /* Copybutton settings */

--- a/tests/integration/example/myst-examples.md
+++ b/tests/integration/example/myst-examples.md
@@ -43,6 +43,30 @@ input line 2
 input line 3
 ```
 
+## Stacked terminals
+
+```{terminal}
+:copy:
+:user: author
+:host: canonical
+:dir: ~/path
+
+input 1
+
+output 1
+```
+
+```{terminal}
+:copy:
+:user: author
+:host: canonical
+:dir: ~/path
+
+input 2
+
+output 2
+```
+
 ## Code blocks
 
 ```{code-block}

--- a/tests/integration/example/rst-examples.rst
+++ b/tests/integration/example/rst-examples.rst
@@ -50,6 +50,32 @@ No output
     input line 2
 
 
+Stacked terminals
+-----------------
+
+.. terminal::
+    :copy:
+    :scroll:
+    :user: author
+    :host: canonical
+    :dir: ~/path
+
+    input 1
+
+    output 1
+
+.. terminal::
+    :copy:
+    :scroll:
+    :user: author
+    :host: canonical
+    :dir: ~/path
+
+    input 2
+
+    output 2
+
+
 Code blocks
 -----------
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Adds styling rules to merge consecutive terminal blocks in the output.

```rst
.. terminal::
    :copy:
    :scroll:
    :user: author
    :host: canonical
    :dir: ~/path

    input 1

    output 1

.. terminal::
    :copy:
    :scroll:
    :user: author
    :host: canonical
    :dir: ~/path

    input 2

    output 2
```

<img width="1456" height="271" alt="image" src="https://github.com/user-attachments/assets/2dc08893-93ca-43c4-ac3f-f9d037ac7a8a" />

This was the solution agreed upon in https://github.com/canonical/sphinx-terminal/issues/32.