### PR TITLE
fix: hide CSS-only tooltip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include common.mk
 format: format-ruff format-codespell format-prettier  ## Run all automatic formatters
 
 .PHONY: lint
-lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-twine  ## Run all linters
+lint: setup-lint lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-twine  ## Run all linters
 
 .PHONY: pack
 pack: pack-pip  ## Build all packages

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -98,3 +98,8 @@ button.copybtn.success {
     color 0.3s,
     opacity 0.3s;
 }
+
+/* Hide the default CSS tooltip */
+.terminal .o-tooltip--left:hover:after {
+  display: none;
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

## Overview

Resolves https://github.com/canonical/sphinx-terminal/issues/21.

The text for the remaining tooltip is a [hard-coded localization string](https://github.com/executablebooks/sphinx-copybutton/blob/ef430062a3b7b2046f0283dcc42ee696e5878fd9/sphinx_copybutton/_static/copybutton.js_t#L5), so I'd rather leave it as is. Overriding it would be a little too hacky for my liking.

(+ a fly-by fix to the `make lint` target)

## Testing instructions

* Check out the branch
* Run `make test`
* Open `.test_output/rst-examples.html` in your browser
* Hover over any of the terminal copy buttons