### PR TITLE
fix: allow empty input lines

### DIFF
--- a/sphinx_terminal/directive.py
+++ b/sphinx_terminal/directive.py
@@ -60,16 +60,14 @@ class TerminalDirective(SphinxDirective):
         prompt_container.append(prompt)
         input_line.append(prompt_container)
 
-        command = nodes.inline()
+        if commands:
+            command_node = nodes.inline()
+            command_node.extend(nodes.literal(text=f"{line}\n") for line in commands)
+            command_node["classes"].append("command")
+            if is_copyable:
+                command_node["classes"].append("copybutton")
+            input_line.append(command_node)
 
-        for line in commands:
-            command.append(nodes.literal(text=f"{line}\n"))
-
-        command["classes"].append("command")
-        if is_copyable:
-            command["classes"].append("copybutton")
-
-        input_line.append(command)
         return input_line
 
     def run(self) -> list[nodes.Node]:
@@ -80,23 +78,27 @@ class TerminalDirective(SphinxDirective):
         host = self.options.get("host", "host")
         prompt_dir = self.options.get("dir", "~")
         user_symbol = "#" if user == "root" else "$"
-        has_input = "output-only" not in self.options
 
         # Raise an error if :copy: and :output-only: are both declared
         if "output-only" in self.options and "copy" in self.options:
             raise SphinxError(
-                ":copy: and :output-only: are mutually incompatible. Only input can be copied."
+                "'copy' and 'output-only' are mutually incompatible. Only input can be copied."
             )
 
-        if user and host:
-            prompt_text = f"{user}@{host}:{prompt_dir}{user_symbol} "
-        elif user and not host:
-            # Only the user is supplied
-            prompt_text = f"{user}:{prompt_dir}{user_symbol} "
-        else:
-            # Omit both user and host, just showing the host
-            # doesn't really make sense
-            prompt_text = f"{prompt_dir}{user_symbol} "
+        # Raise an error if :output-only" is declared without output.
+        if "output-only" in self.options and not self.content:
+            raise SphinxError(
+                "'output-only' was declared, but no output was provided."
+                "Provide output or remove the 'output-only' option."
+            )
+
+        prompt_text = (
+            f"{user}@{host}:{prompt_dir}{user_symbol} "
+            if user and host
+            else f"{user}:{prompt_dir}{user_symbol} "
+            if user
+            else f"{prompt_dir}{user_symbol} "
+        )
 
         out = nodes.container()
         out["classes"].append("terminal")
@@ -117,6 +119,7 @@ class TerminalDirective(SphinxDirective):
         output_lines: list[str] = []
 
         # Add the prompt and input
+        has_input = "output-only" not in self.options
         for line in self.content:
             if has_input:
                 if has_input := bool(line.strip()):
@@ -124,11 +127,17 @@ class TerminalDirective(SphinxDirective):
             else:
                 output_lines += [line]
 
-        if input_lines:
+        input_lines = (
+            [input_lines[0]] + ["> " + line for line in input_lines[1:]]
+            if input_lines
+            else []
+        )
+
+        if "output-only" not in self.options:
             out.append(
                 self.input_line(
                     prompt_text,
-                    [input_lines[0]] + ["> " + line for line in input_lines[1:]],
+                    input_lines,
                     is_copyable="copy" in self.options,
                 )
             )

--- a/sphinx_terminal/directive.py
+++ b/sphinx_terminal/directive.py
@@ -82,13 +82,14 @@ class TerminalDirective(SphinxDirective):
         # Raise an error if :copy: and :output-only: are both declared
         if "output-only" in self.options and "copy" in self.options:
             raise SphinxError(
-                "'copy' and 'output-only' are mutually incompatible. Only input can be copied."
+                "'copy' and 'output-only' are mutually incompatible. "
+                "Only input can be copied."
             )
 
         # Raise an error if :output-only" is declared without output.
         if "output-only" in self.options and not self.content:
             raise SphinxError(
-                "'output-only' was declared, but no output was provided."
+                "'output-only' was declared, but no output was provided. "
                 "Provide output or remove the 'output-only' option."
             )
 

--- a/tests/integration/example/myst-examples.md
+++ b/tests/integration/example/myst-examples.md
@@ -43,6 +43,15 @@ input line 2
 input line 3
 ```
 
+## No input or output
+
+```{terminal}
+:copy:
+:user: author
+:host: canonical
+:dir: ~/path
+```
+
 ## Stacked terminals
 
 ```{terminal}

--- a/tests/integration/example/rst-examples.rst
+++ b/tests/integration/example/rst-examples.rst
@@ -50,6 +50,17 @@ No output
     input line 2
 
 
+No input or output
+------------------
+
+.. terminal::
+    :copy:
+    :scroll:
+    :user: author
+    :host: canonical
+    :dir: ~/path
+
+
 Stacked terminals
 -----------------
 

--- a/tests/unit/terminal_unit_test.py
+++ b/tests/unit/terminal_unit_test.py
@@ -258,7 +258,7 @@ def test_terminal_multiline(fake_terminal_directive):
     ],
     indirect=True,
 )
-def test_terminal_no_input(fake_terminal_directive):
+def test_terminal_output_only(fake_terminal_directive):
     expected = nodes.container()
     expected["classes"] = "terminal"
 
@@ -272,6 +272,40 @@ def test_terminal_no_input(fake_terminal_directive):
     output_block["classes"] = "terminal-code"
     output_block["xml:space"] = "preserve"
     expected.append(output_block)
+
+    actual = fake_terminal_directive.run()[0]
+
+    assert str(expected) == str(actual)
+
+
+@pytest.mark.parametrize(
+    "fake_terminal_directive",
+    [
+        {
+            "content": [],
+        }
+    ],
+    indirect=True,
+)
+def test_terminal_empty_input_line(fake_terminal_directive):
+    expected = nodes.container()
+    expected["classes"] = "terminal"
+
+    highlight = addnodes.highlightlang()
+    highlight["force"] = "False"
+    highlight["lang"] = "text"
+    highlight["linenothreshold"] = "10000"
+    expected.append(highlight)
+
+    input_container = nodes.container()
+    input_container["classes"] = "input"
+
+    prompt_container = nodes.container()
+    prompt_container["classes"] = "prompt"
+    prompt_text = nodes.literal(text="user@host:~$ ")
+    prompt_container.append(prompt_text)
+    input_container.append(prompt_container)
+    expected.append(input_container)
 
     actual = fake_terminal_directive.run()[0]
 
@@ -333,5 +367,21 @@ def test_terminal_no_output(fake_terminal_directive):
     indirect=True,
 )
 def test_terminal_copy_output_only(fake_terminal_directive):
+    with pytest.raises(SphinxError):
+        fake_terminal_directive.run()
+
+
+@pytest.mark.parametrize(
+    "fake_terminal_directive",
+    [
+        {
+            "options": {
+                "output-only": None,
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_terminal_output_only_no_output(fake_terminal_directive):
     with pytest.raises(SphinxError):
         fake_terminal_directive.run()


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

## Overview

Resolves #62.

Currently, the directive outputs a black box if no content is given. I think this behavior makes more sense, as an empty directive now displays an empty terminal.

This doesn't affect existing use cases, such as displaying only output. To prevent the aforementioned empty black box, the extension now throws an error if `output-only` is declared without directive content.

## Input / Output

### Input

```
.. terminal::
    :user: author
    :host: canonical
    :dir: ~/path
```


###Output

Before:

<img width="727" height="20" alt="image" src="https://github.com/user-attachments/assets/b50d0ea8-1e53-4429-9966-d863d4ba2f55" />


After:

<img width="728" height="38" alt="image" src="https://github.com/user-attachments/assets/5357827b-3d83-49a4-84cd-fb0966e1c5ff" />