### PR TITLE
fix: make input respect 'scroll' option

### DIFF
--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -38,6 +38,7 @@
 .terminal .input .literal {
   white-space-collapse: preserve-breaks;
   background: transparent;
+  padding-left: 0;
 }
 
 .terminal .input .prompt {
@@ -46,18 +47,34 @@
   color: yellowgreen;
 }
 
-.terminal.scroll .input,
-.terminal.scroll .output {
-  width: max-content;
-}
-
 .terminal-code pre {
   font-size: var(--font-size--small--2);
   background-color: #2b2b2b;
+  white-space: pre-wrap;
 }
 
 div.terminal-code {
   margin: 0;
+}
+
+/* Rules for the 'scroll' option */
+.terminal.scroll {
+  overflow-x: auto;
+
+  .container.input {
+    display: flex;
+    white-space: nowrap;
+    width: max-content;
+  }
+
+  .terminal-code {
+    width: max-content;
+  }
+
+  button.copybtn {
+    position: sticky;
+    margin-left: auto;
+  }
 }
 
 /* Copybutton settings */
@@ -68,7 +85,7 @@ div.input {
 
 div.input > button.copybtn {
   overflow-y: visible;
-  top: 0.1em;
+  top: 0;
   right: 0.1em;
   width: 1.4em;
   height: 1.4em;
@@ -84,13 +101,9 @@ button.copybtn.success {
   opacity: 1;
 }
 
-.terminal.scroll > .input {
-  width: inherit;
-}
-
 .input button.copybtn {
   align-items: center;
-  background-color: inherit;
+  background-color: #2b2b2b;
   border: none;
   color: #f8f8f8;
   cursor: pointer;

--- a/tests/integration/example/myst-examples.md
+++ b/tests/integration/example/myst-examples.md
@@ -67,6 +67,35 @@ input 2
 output 2
 ```
 
+## Scrolling and line wrapping
+
+The following input and output should line wrap.
+
+```{terminal}
+:copy:
+:user: author
+:host: canonical
+:dir: ~/path
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+```
+
+The following input and output should be scrollable.
+
+```{terminal}
+:copy:
+:scroll:
+:user: author
+:host: canonical
+:dir: ~/path
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+```
+
 ## Code blocks
 
 ```{code-block}

--- a/tests/integration/example/rst-examples.rst
+++ b/tests/integration/example/rst-examples.rst
@@ -6,7 +6,6 @@ Multi-line input
 
 .. terminal::
     :copy:
-    :scroll:
     :user: author
     :host: canonical
     :dir: ~/path
@@ -24,7 +23,6 @@ No input
 --------
 
 .. terminal::
-    :scroll:
     :user: author
     :host: canonical
     :dir: ~/path
@@ -41,7 +39,6 @@ No output
 
 .. terminal::
     :copy:
-    :scroll:
     :user: author
     :host: canonical
     :dir: ~/path
@@ -55,7 +52,6 @@ Stacked terminals
 
 .. terminal::
     :copy:
-    :scroll:
     :user: author
     :host: canonical
     :dir: ~/path
@@ -66,7 +62,6 @@ Stacked terminals
 
 .. terminal::
     :copy:
-    :scroll:
     :user: author
     :host: canonical
     :dir: ~/path
@@ -74,6 +69,35 @@ Stacked terminals
     input 2
 
     output 2
+
+
+Line wrapping and scrolling
+---------------------------
+
+The following input and output should line wrap.
+
+.. terminal::
+    :copy:
+    :user: author
+    :host: canonical
+    :dir: ~/path
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+
+The following input and output should be scrollable.
+
+.. terminal::
+    :copy:
+    :scroll:
+    :user: author
+    :host: canonical
+    :dir: ~/path
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
 
 
 Code blocks


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* Makes output lines wrap by default
* Make input lines respect the `scroll` option
* Fix the copy button's position as the container scrolls
* Give the copy button a solid background
  * It's very hard to make it out over scrollable inputs otherwise
* Align the prompt with the left edge of the container
* Align top of copy button with the input container

Resolves #46.
