### PR TITLE
feat: add a more flexible 'prompt' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ and `:dir:` options.
     hello
 ```
 
+Or, declare the entire prompt with the `prompt` option. This is useful if you're
+documenting shells other than Bash, such as PowerShell:
+
+```
+.. terminal::
+    :prompt: PS C:\Users\Author>
+
+    Write-Output 'hello'
+
+    hello
+```
+
 To render only the output of a command, include the `:output-only:` flag in the
 directive's options.
 

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -38,7 +38,7 @@
 .terminal .input .literal {
   white-space-collapse: preserve-breaks;
   background: transparent;
-  padding-left: 0;
+  padding: 0;
 }
 
 .terminal .input .prompt {

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -42,7 +42,7 @@
 }
 
 .terminal .input .prompt {
-  display: inline-block;
+  display: inline;
   font-weight: bold;
   color: yellowgreen;
 }

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -36,7 +36,7 @@
 }
 
 .terminal .input .literal {
-  white-space-collapse: preserve-breaks;
+  white-space-collapse: break-spaces;
   background: transparent;
   padding-left: 0;
 }

--- a/sphinx_terminal/_static/terminal.css
+++ b/sphinx_terminal/_static/terminal.css
@@ -36,7 +36,7 @@
 }
 
 .terminal .input .literal {
-  white-space-collapse: break-spaces;
+  white-space-collapse: preserve-breaks;
   background: transparent;
   padding-left: 0;
 }

--- a/sphinx_terminal/directive.py
+++ b/sphinx_terminal/directive.py
@@ -63,7 +63,7 @@ class TerminalDirective(SphinxDirective):
 
         if commands:
             command_node = nodes.inline()
-            command_node.extend(nodes.literal(text=f"{line}\n") for line in commands)
+            command_node.append(nodes.literal(text="\n".join(commands)))
             command_node["classes"].append("command")
             if is_copyable:
                 command_node["classes"].append("copybutton")

--- a/sphinx_terminal/directive.py
+++ b/sphinx_terminal/directive.py
@@ -31,6 +31,7 @@ class TerminalDirective(SphinxDirective):
     has_content = True
     option_spec = {
         "class": directives.class_option,
+        "prompt": directives.unchanged,
         "user": directives.unchanged,
         "host": directives.unchanged,
         "dir": directives.unchanged,
@@ -93,8 +94,16 @@ class TerminalDirective(SphinxDirective):
                 "Provide output or remove the 'output-only' option."
             )
 
+        if "prompt" in self.options and self.options.keys() & {"user", "host", "dir"}:
+            raise SphinxError(
+                "The 'prompt' option is incompatible with the 'user', 'host', and 'dir' options. "
+                "Remove the 'prompt' option or the 'user', 'host', and 'dir' options."
+            )
+
         prompt_text = (
-            f"{user}@{host}:{prompt_dir}{user_symbol} "
+            self.options.get("prompt", "")
+            if "prompt" in self.options
+            else f"{user}@{host}:{prompt_dir}{user_symbol} "
             if user and host
             else f"{user}:{prompt_dir}{user_symbol} "
             if user

--- a/sphinx_terminal/directive.py
+++ b/sphinx_terminal/directive.py
@@ -101,7 +101,7 @@ class TerminalDirective(SphinxDirective):
             )
 
         prompt_text = (
-            self.options.get("prompt", "")
+            f"{self.options.get('prompt', '')} "
             if "prompt" in self.options
             else f"{user}@{host}:{prompt_dir}{user_symbol} "
             if user and host

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -3,7 +3,9 @@ Test doc
 ========
 
 This document is parsed with bs4 to ensure that the rendered HTML matches the
-expected output:
+expected output.
+
+First, we test the user-host-dir syntax:
 
 .. terminal::
     :copy:
@@ -15,6 +17,17 @@ expected output:
     input
 
     output
+
+Then, the simpler prompt syntax:
+
+.. terminal::
+    :copy:
+    :scroll:
+    :prompt: PS C:\Users\JJ>
+
+    I'm a PowerShell user now.
+
+    Hooray.
 
 The following documents include more examples for manual review:
 

--- a/tests/integration/example/rst-examples.rst
+++ b/tests/integration/example/rst-examples.rst
@@ -16,7 +16,7 @@ Multi-line input
     output line 1
     output line 2
 
-    output line-3
+    output line 3
 
 
 No input

--- a/tests/integration/terminal_integration_test.py
+++ b/tests/integration/terminal_integration_test.py
@@ -52,7 +52,8 @@ def test_terminal_integration(example_project):
     shutil.rmtree(example_project)  # Delete copied source
 
     # Ensure that the :copy: and :scroll: options are respected
-    assert soup.find("div", {"class": "terminal scroll docutils container"})
+    terminals = soup.find_all("div", {"class": "terminal scroll docutils container"})
+    assert len(terminals) == 2
 
     # Ensure that the prompt renders correctly
     prompt_html = soup.find("span", {"class": "pre"})
@@ -80,3 +81,7 @@ def test_terminal_integration(example_project):
         "code", {"class": "command docutils literal notranslate"}
     )
     assert not input_html
+
+    second_prompt = terminals[1].find_all("span", {"class": "pre"})
+    assert getattr(second_prompt[0], "text", "") == "PS"
+    assert getattr(second_prompt[1], "text", "") == "C:\\Users\\JJ>"

--- a/tests/unit/terminal_unit_test.py
+++ b/tests/unit/terminal_unit_test.py
@@ -46,7 +46,7 @@ def test_terminal_directive(fake_terminal_directive):
 
     command_container = nodes.inline()
     command_container["classes"] = "command"
-    command = nodes.literal(text="echo 'hello'\n")
+    command = nodes.literal(text="echo 'hello'")
     command_container.append(command)
     input_container.append(command_container)
     expected.append(input_container)
@@ -95,7 +95,7 @@ def test_terminal_directive_prompt(fake_terminal_directive):
 
     command_container = nodes.inline()
     command_container["classes"] = "command"
-    command = nodes.literal(text="echo 'hello'\n")
+    command = nodes.literal(text="echo 'hello'")
     command_container.append(command)
     input_container.append(command_container)
     expected.append(input_container)
@@ -144,7 +144,7 @@ def test_terminal_copy_scroll(fake_terminal_directive):
 
     command_container = nodes.inline()
     command_container["classes"] = "command copybutton"
-    command = nodes.literal(text="echo 'hello'\n")
+    command = nodes.literal(text="echo 'hello'")
     command_container.append(command)
     input_container.append(command_container)
     expected.append(input_container)
@@ -190,7 +190,7 @@ def test_terminal_class_option(fake_terminal_directive):
 
     command_container = nodes.inline()
     command_container["classes"] = "command"
-    command = nodes.literal(text="echo 'hello'\n")
+    command = nodes.literal(text="echo 'hello'")
     command_container.append(command)
     input_container.append(command_container)
     expected.append(input_container)
@@ -234,9 +234,7 @@ def test_terminal_multiline(fake_terminal_directive):
     input_container.append(prompt_container)
 
     command_container = nodes.inline()
-    command = nodes.literal(text="echo 'hello'\n")
-    command_container.append(command)
-    command = nodes.literal(text="> echo 'test'\n")
+    command = nodes.literal(text="echo 'hello'\n> echo 'test'")
     command_container.append(command)
     command_container["classes"] = "command"
     input_container.append(command_container)
@@ -345,16 +343,14 @@ def test_terminal_no_output(fake_terminal_directive):
     input_container.append(prompt_container)
 
     command_container = nodes.inline()
-    command = nodes.literal(text="echo 'hello'\n")
-    command_container.append(command)
-    command = nodes.literal(text="> echo 'test'\n")
+    command = nodes.literal(text="echo 'hello'\n> echo 'test'")
     command_container.append(command)
     command_container["classes"] = "command"
     input_container.append(command_container)
     expected.append(input_container)
 
     actual = fake_terminal_directive.run()[0]
-
+    print(f"\n\n{expected}\n\n{actual}\n\n")
     assert str(expected) == str(actual)
 
 

--- a/tests/unit/terminal_unit_test.py
+++ b/tests/unit/terminal_unit_test.py
@@ -59,14 +59,18 @@ def test_terminal_directive(fake_terminal_directive):
 @pytest.mark.parametrize(
     "fake_terminal_directive",
     [
-        {
-            "options": {
-                "user": "author",
-                "host": "canonical",
-                "dir": "~/path",
-            },
-            "content": ["echo 'hello'", "", "hello"],
-        }
+        pytest.param(
+            {
+                "options": {"user": "author", "host": "canonical", "dir": "~/path"},
+                "content": ["echo 'hello'", "", "hello"],
+            }
+        ),
+        pytest.param(
+            {
+                "options": {"prompt": "author@canonical:~/path$ "},
+                "content": ["echo 'hello'", "", "hello"],
+            }
+        ),
     ],
     indirect=True,
 )
@@ -383,5 +387,29 @@ def test_terminal_copy_output_only(fake_terminal_directive):
     indirect=True,
 )
 def test_terminal_output_only_no_output(fake_terminal_directive):
+    with pytest.raises(SphinxError):
+        fake_terminal_directive.run()
+
+
+@pytest.mark.parametrize(
+    "fake_terminal_directive",
+    [
+        pytest.param({"options": {"prompt": "test", "user": "author"}}),
+        pytest.param({"options": {"prompt": "test", "host": "canonical"}}),
+        pytest.param({"options": {"prompt": "test", "dir": "/path"}}),
+        pytest.param(
+            {
+                "options": {
+                    "prompt": "test",
+                    "user": "author",
+                    "host": "canonical",
+                    "dir": "/path",
+                }
+            }
+        ),
+    ],
+    indirect=True,
+)
+def test_incompatible_prompt_options(fake_terminal_directive):
     with pytest.raises(SphinxError):
         fake_terminal_directive.run()

--- a/tests/unit/terminal_unit_test.py
+++ b/tests/unit/terminal_unit_test.py
@@ -67,7 +67,7 @@ def test_terminal_directive(fake_terminal_directive):
         ),
         pytest.param(
             {
-                "options": {"prompt": "author@canonical:~/path$ "},
+                "options": {"prompt": "author@canonical:~/path$"},
                 "content": ["echo 'hello'", "", "hello"],
             }
         ),


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* Add a more flexible `prompt` option that allows users to specify the entire prompt. This flexibility will allow products like WSL to adopt the extension.
* Throw an error if the new prompt syntax is used in tandem with the user-host-dir syntax.
* Remove some unnecessary padding around the prompt.
* Patch out an unnecessary newline.

This change is entirely backward-compatible.

Resolves #64.